### PR TITLE
Change_Network_Settings

### DIFF
--- a/NetworkSettings.json
+++ b/NetworkSettings.json
@@ -54,7 +54,7 @@
     "Endpoint": "https://polygon-rpc.com",
     "WS": "polygon",
     "Factory": "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506",
-    "Name": "Polygon/ Matic",
+    "Name": "Polygon",
     "TokenSylmbol": "MATIC",
     "CurrencyAddress": "0x0000000000000000000000000000000000001010",
     "PairCurrency": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"
@@ -66,7 +66,7 @@
     "Endpoint": "https://matic-mumbai.chainstacklabs.com",
     "WS": "mumbai",
     "Factory": "0x9Ac64Cc6e4415144C455BD8E4837Fea55603e5c3",
-    "Name": "Polygon/ Matic",
+    "Name": "Polygon",
     "TokenSylmbol": "MATIC",
     "CurrencyAddress": "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889",
     "PairCurrency": "0xc2132D05D31c914a87C6611C10748AEb04B58e8F"


### PR DESCRIPTION
Updating network settings, due to the new data scraping model, NetworkSettings entities names are now utilized as a network prefix, for local files, due that it's not possible to have special characters.