### PR TITLE
Resolving security issue

### DIFF
--- a/Pages/Create.razor
+++ b/Pages/Create.razor
@@ -304,7 +304,7 @@
 
         try
         {
-            var passwrod = HardwareService.Encrypt(PassCode, "iV1z@$H8");
+            var passwrod = HardwareService.Encrypt("iV1z@$H8",PassCode);
             var PK = HardwareService.Encrypt(Wallet.PrivateKey, PassCode);
 
             switch (Communication.SoftwareType)

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -65,8 +65,8 @@
     private IHardwareService HardwareService { get; set; }
     private string Port{ get; set; }
 
-  
- 
+
+
     protected override Task OnAfterRenderAsync(bool firstRender)
     {
 
@@ -84,8 +84,8 @@
 
 
     }
- 
- 
+
+
 
     private void LoadHotWallet()
     {
@@ -100,8 +100,8 @@
 
     private void LoadColdWallet()
     {
+        Communication.SoftwareType = ConfigMode.ColdWallet;
         NavigationManager.NavigateTo("HardwareSelect");
-
     }
 
 }

--- a/Pages/LoginPanel.razor
+++ b/Pages/LoginPanel.razor
@@ -100,7 +100,7 @@
             return;
         }
 
-        var passwrod = HardwareService.Encrypt(Password, "iV1z@$H8");
+        var passwrod = HardwareService.Encrypt("iV1z@$H8",Password);
         Communication.Pass = Password;
 
         switch(Communication.SoftwareType)

--- a/Services/Implementation/Communication.cs
+++ b/Services/Implementation/Communication.cs
@@ -1,6 +1,5 @@
 ﻿
 using ArduinoUploader.Hardware;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using NFTLock.Models;
 using SYNCWallet.Models;


### PR DESCRIPTION
Resolving security issue, due to creating encoding of the password for parity with seed it was possible to decode the original pin using the seed from the in-memory data. Now after the roles are reversed it's no longer possible to decode the parity pair unless the user knows the pin for the wallet for both hardware and software versions.