### PR TITLE
Adding bindings to the Price change widget

### DIFF
--- a/src/Application/Implementation/Utilities.cs
+++ b/src/Application/Implementation/Utilities.cs
@@ -203,6 +203,14 @@ namespace SYNCWallet.Services.Implementation
                 }
             }
         }
+        
+        public double DateTimeToUnixTimestamp(DateTime dateTime)
+        {
+            DateTime unixStart = new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc);
+            long unixTimeStampInTicks = (dateTime.ToUniversalTime() - unixStart).Ticks;
+            return (double)unixTimeStampInTicks / TimeSpan.TicksPerSecond;
+        }
+
 
     }
 }

--- a/src/Domain/Models/CurrentBar.cs
+++ b/src/Domain/Models/CurrentBar.cs
@@ -1,0 +1,14 @@
+namespace Domain.Models
+{
+    public class CurrentBar
+    {
+        public string s { get; set; }
+        public List<decimal> t { get; set; }
+        public List<decimal> c { get; set; }
+        public List<decimal> o { get; set; }
+        public List<decimal> h { get; set; }
+        public List<decimal> l { get; set; }
+        public List<decimal> v { get; set; }
+        public decimal nextTime { get; set; }
+    }
+}

--- a/src/Infrastructure/Services/IContractService.cs
+++ b/src/Infrastructure/Services/IContractService.cs
@@ -191,5 +191,11 @@ namespace SYNCWallet.Services.Definitions
         /// </summary>
         public Task<(decimal,decimal)> GetContractLpSupply(TokenContract token);
 
+        /// <summary>
+        /// Returns a list of token prices representing price changes across 24h 1 month and 1 year.
+        /// Parameters:
+        /// <param name="symbol">Blockchain address of a token, must be on the whitelisted network.</param>
+        /// </summary>
+        public Task<( decimal lastDayPercentage,decimal lastMonthPercentage, decimal lastYearPercentage)> GetPriceChange(string symbol);
     }
 }

--- a/src/Infrastructure/Services/IUtilities.cs
+++ b/src/Infrastructure/Services/IUtilities.cs
@@ -133,5 +133,13 @@ namespace SYNCWallet.Services.Definitions
         /// <param name="url">The website URL</param>
         /// </summary>
         void OpenBrowser(string url);
+
+        /// <summary>
+        /// Converts DateTime to unix timestamp
+        /// Parameters:
+        /// <paramref name="dateTime"/>
+        /// <param name="dateTime">Valid DateTime object to be converted</param>
+        /// </summary>
+        double DateTimeToUnixTimestamp(DateTime dateTime);
     }
 }

--- a/src/Presentation/Components/PriceChangeComponent.razor
+++ b/src/Presentation/Components/PriceChangeComponent.razor
@@ -1,0 +1,31 @@
+ 
+@namespace SYNCWallet.Components.PriceChanges
+
+<div class="card" style="height: 95%;">
+    <div class="card-body" style="display: flex;
+                                      flex-direction: column;
+                                      justify-content: space-evenly;
+                                      align-content: space-around;">
+        <h3 class="text-center">
+             Price changes
+        </h3>
+        <div class="row">
+            <h4>Daily change</h4>
+            <div class="progress" style="height: 10px;">
+                <div class="progress-bar @DailyBackground" style="width: @DailyChange%;" role="progressbar">@DailyChange%</div>
+            </div>
+        </div>
+        <div class="row">
+            <h4>Monthly change</h4>
+            <div class="progress" style="height: 10px;">
+                <div class="progress-bar @MonthlyBackground" style="width: @MonthlyChange%;" role="progressbar">@MonthlyChange%</div>
+            </div>
+        </div>
+        <div class="row">
+            <h4>Yearly change</h4>
+            <div class="progress" style="height: 10px;">
+                <div class="progress-bar @YearlyBackground" style="width: @YearlyChange%;" role="progressbar">@YearlyChange%</div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Presentation/Components/PriceChangeComponent.razor.cs
+++ b/src/Presentation/Components/PriceChangeComponent.razor.cs
@@ -1,0 +1,70 @@
+using System.Drawing;
+using LInksync_Cold_Storage_Wallet.Handlers;
+using LInksync_Cold_Storage_Wallet.Services.Implementation;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using SYNCWallet.Services;
+using SYNCWallet.Services.Definitions;
+
+namespace SYNCWallet.Components.PriceChanges
+{
+    public partial class PriceChangeComponent
+    {
+        [Inject]
+        private IJSRuntime JS { get; set; }
+
+        private IContractService ContractService { get; set; }
+        private ICommunication Communication { get; set; }
+        public decimal DailyChange { get; set; }
+        public string DailyBackground { get; set; }
+        public decimal MonthlyChange { get; set; }
+        public string MonthlyBackground { get; set; }
+        public decimal YearlyChange { get; set; }
+        public string YearlyBackground { get; set; }
+
+
+        
+        protected override async Task OnInitializedAsync()
+        {
+            ContractService = ServiceHelper.GetService<IContractService>();
+            Communication = ServiceHelper.GetService<ICommunication>();
+            TrackerHandler.NotifyChildren += ParentUpdated;
+
+        }
+
+        private async void ParentUpdated()
+        {
+            await LoadContractPriceChanges();
+            InvokeAsync(() =>
+            {
+                this.StateHasChanged();
+            });
+        }
+
+        private async Task LoadContractPriceChanges()
+        {
+            var priceChanges = await ContractService.GetPriceChange(Communication.SelectedContract.ContractAddress);
+            DailyChange = priceChanges.lastDayPercentage;
+            MonthlyChange = priceChanges.lastMonthPercentage;
+            YearlyChange = priceChanges.lastYearPercentage;
+            
+            if (DailyChange > 0)
+                DailyBackground = "bg-success";
+            else
+                DailyBackground = "bg-error";
+            
+            if (MonthlyChange > 0)
+                MonthlyBackground = "bg-success";
+            else
+                MonthlyBackground = "bg-error";
+            
+            if (YearlyChange > 0)
+                YearlyBackground = "bg-success";
+            else
+                YearlyBackground = "bg-error";
+        }
+        
+
+
+    }
+}

--- a/src/Presentation/Components/TrackerNavigationComponent.razor
+++ b/src/Presentation/Components/TrackerNavigationComponent.razor
@@ -3,7 +3,7 @@
 
 
  
-<div class="row">
+<div class="row" style="margin-top: 15px;">
     <div class="col-lg-12" >
         <div class="card CardFluent">
             <div class="card-header TokenTimeline">

--- a/src/Presentation/Components/TrackerNavigationComponent.razor.cs
+++ b/src/Presentation/Components/TrackerNavigationComponent.razor.cs
@@ -15,6 +15,8 @@ namespace SYNCWallet.Components.Navigation
                 
         [Inject]
         NavigationManager NavigationManager { get; set; }
+        [Inject]
+        private IJSRuntime JS { get; set; }
         
         [Parameter]
         public Token CurrentToken { get; set; }
@@ -23,9 +25,23 @@ namespace SYNCWallet.Components.Navigation
 
         private ICommunication _Communication { get; set; }
         private IContractService _contractService { get; set; }
+        public bool IsChartRendered { get; set; }
+
 
         public List<NetworkTokenGroup> ListedTokens { get; set; }
         public object ItemChanged { get; set; }
+
+        protected override Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (!IsChartRendered)
+            {
+                Task.Run(() => JS.InvokeAsync<string>("InitDropdown"));
+                IsChartRendered = !IsChartRendered;
+            }
+
+            return base.OnAfterRenderAsync(firstRender);
+        }
+
 
 
         protected override async Task OnInitializedAsync()

--- a/src/Presentation/Pages/TrackerLanding.razor
+++ b/src/Presentation/Pages/TrackerLanding.razor
@@ -3,6 +3,7 @@
 @using SYNCWallet.Models
 @using SYNCWallet.Components.Navigation
 @using SYNCWallet.Components.Transactions
+@using SYNCWallet.Components.PriceChanges
 
 <link href="/css/Tracker.css" rel="stylesheet">
  
@@ -280,15 +281,9 @@
                         </div>
                     </div>
                     <div class="col-lg-4">
-                        <div class="card" style="height: 95%;">
-                            <div class="card-body">
-                                <h3 class="text-center">
-                                     Price change in %
-                                </h3>
-                                <div id="morris-donut-chart"></div>
+                        <PriceChangeComponent>
                             
-                            </div>
-                        </div>
+                        </PriceChangeComponent>
                     </div>
             </div>
         </div>

--- a/src/Presentation/Pages/TrackerLanding.razor.cs
+++ b/src/Presentation/Pages/TrackerLanding.razor.cs
@@ -30,8 +30,8 @@ namespace LInksync_Cold_Storage_Wallet.Pages
         {
             if (!IsChartRendered)
             {
- 
-                Task.Run(() => JS.InvokeAsync<string>("InitDonut"));
+                Task.Run(() => JS.InvokeAsync<string>("InitBalanceChart"));
+
                 Task.Run(() => JS.InvokeVoidAsync("LoadSocialMediaFeed", "TwitterFeed", Communication.SelectedToken.TwitterFeed)); 
                 Task.Run(() => JS.InvokeVoidAsync("LoadSocialMediaFeed", "InstagramFeed", Communication.SelectedToken.InstagramFeed));
                 Task.Run(() => JS.InvokeVoidAsync("LoadSocialMediaFeed", "YoutubeFeed", Communication.SelectedToken.YoutubeFeed));

--- a/src/Presentation/wwwroot/css/Tracker.css
+++ b/src/Presentation/wwwroot/css/Tracker.css
@@ -132,7 +132,7 @@
     color: red;
     background: none;
     border: none;
-     
+    width: 100%;
     padding: 28px;
     display: flex;
     align-content: center;

--- a/src/Presentation/wwwroot/js/Index.js
+++ b/src/Presentation/wwwroot/js/Index.js
@@ -363,32 +363,19 @@ function RiseError(title, message)
     Swal.fire(title,message);
 }
 
-function InitDonut()
+function InitDropdown()
 {
     $(".select2").select2().on('select2:select', function (e) {
         console.log(e.params.data);
         DotNet.invokeMethodAsync('LInksync-Cold-Storage-Wallet', 'TokenSelected', e.params.data.id);
-        
-    });
 
-    //#c43939 red
-    //39c449 green
-    Morris.Donut({
-        element: 'morris-donut-chart',
-        data: [{
-            label: "Daily",
-            value: 12,
-
-        }, {
-            label: "Monthly",
-            value: 30
-        }, {
-            label: "Yearly",
-            value: 20
-        }],
-        resize: true,
-        colors:['#009efb', '#39c449', '#2f3d4a']
     });
+}
+
+function InitBalanceChart()
+{
+ 
+    
     var myChart = echarts.init(document.getElementById('basic-line'));
 
     // specify chart configuration item and data


### PR DESCRIPTION
Extending the ContractService, adding a new method to get a whitelisted token price change for 24 h, 1month and 1 year. Moving out the boilerplate widget code into a separate component and replacing the donuts with an easier to understand bar line for the data presentation